### PR TITLE
Add support for .spicy files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vim-spicy
 
-Syntax highlighting for BinPAC++/Spicy grammar files (pac2).
+Syntax highlighting for BinPAC++/Spicy grammar files (.pac2/.spicy).
 See http://www.icir.org/hilti/ for details.
 
 Currently, the syntax highlighting is very basic. It's my first Vim plugin. Contributions welcome!

--- a/ftdetect/spicy.vim
+++ b/ftdetect/spicy.vim
@@ -1,1 +1,2 @@
 au BufRead,BufNewFile *.pac2 setfiletype spicy
+au BufRead,BufNewFile *.spicy setfiletype spicy


### PR DESCRIPTION
In newer installations of Spicy the references to BinPAC++ have
been removed and all .pac2 files are now named .spicy